### PR TITLE
chore(deps): stop Dependabot from bumping openssl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    ignore:
+      # openssl must match the default gem of the Ruby in .ruby-version,
+      # otherwise rubygems/release-gem aborts with Gem::LoadError.
+      # Bump it by hand together with .ruby-version.
+      - dependency-name: openssl


### PR DESCRIPTION
Follow-up to #1063, which reverted the `openssl` 3.3.0 → 4.0.2 bump.

The bundler updater runs daily, and nothing currently stops it from proposing that same bump again tomorrow. `openssl` has to match the default gem of the Ruby pinned in `.ruby-version` — `rubygems/release-gem` activates it via RUBYOPT before `Bundler.setup`, so a mismatch aborts the release with `Gem::LoadError`. Since PR checks never run `release.yaml`, the breakage is invisible to CI.

This adds a Dependabot `ignore` rule for `openssl`, so it is bumped by hand together with `.ruby-version` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
