### PR TITLE
chore(ci): use personal git identity for automated commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Git
         run: |
           git config --global user.email "unhappychoice@gmail.com"
-          git config --global user.name "unhappychoice"
+          git config --global user.name "Yuji Ueki"
       - name: Install gem-release
         run: gem install gem-release
       - name: Bump version


### PR DESCRIPTION
Automated commits made by GitHub Actions in this repository were authored as a bot (or under an inconsistent name). This switches them to `Yuji Ueki <unhappychoice@gmail.com>` so the history and contribution graph reflect the actual author.

Workflow logic is unchanged — only the configured commit identity.